### PR TITLE
Correct malformed keyword definition

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -48,6 +48,6 @@ unlatch	KEYWORD2
 #####################################################################################
 ## Functions for getting the lock state
 #####################################################################################
-NUKI_lock_states getLockState	KEYWORD2
+getLockState	KEYWORD2
 isLocked	KEYWORD2
 getBridgeInfo	KEYWORD2


### PR DESCRIPTION
The type was accidentally left on the `getLockState` keyword definition, causing it to not be recognized by the Arduino IDE.